### PR TITLE
Allow reverse proxy scenarios using X-Forwarded-* HTTP headers

### DIFF
--- a/api/odk/controllers/download-submission.js
+++ b/api/odk/controllers/download-submission.js
@@ -8,6 +8,7 @@ const async = require("async");
 const builder = require("xmlbuilder");
 
 const settings = require("../../../settings");
+const Url = require('../../../util/url');
 
 const SUBMISSIONS_DIR = path.join(settings.dataDir, "submissions");
 
@@ -82,7 +83,7 @@ module.exports = (req, res, next) => {
                   .createHash("md5")
                   .update(data)
                   .digest("hex");
-                const downloadUrl = `${req.protocol}://${req.headers.host}/omk/data/submissions/${formId}/${instanceId}/${file}`;
+                const downloadUrl = `${Url.baseUrl(req)}/omk/data/submissions/${formId}/${instanceId}/${file}`;
 
                 xml
                   .ele("mediaFile")

--- a/api/odk/controllers/get-formlist.js
+++ b/api/odk/controllers/get-formlist.js
@@ -3,6 +3,7 @@ var parser = new xml2js.Parser({explicitArray: false, attrkey: "attributes"});
 var createFormList = require('openrosa-formlist');
 var getFormUrls = require('../helpers/get-form-urls');
 var settings = require('../../../settings');
+var Url = require('../../../util/url');
 var fs = require('fs');
 
 /**
@@ -14,7 +15,7 @@ module.exports = function (req, res, next) {
         headers: {
             'User-Agent': 'OpenMapKitServer'
         },
-        baseUrl: req.protocol + '://' + req.headers.host + '/omk/data/forms'
+        baseUrl: Url.baseUrl(req) + '/omk/data/forms'
     };
 
     // Look for "json" query param
@@ -28,7 +29,7 @@ module.exports = function (req, res, next) {
 
         var formListOptions = {
             headers: options.headers,
-            manifestUrl: `${req.protocol}://${req.headers.host}/omk/odk/manifest/\${formId}.xml`
+            manifestUrl: `${Url.baseUrl(req)}/omk/odk/manifest/\${formId}.xml`
         };
 
         return createFormList(formUrls, formListOptions, function (err, xml) {

--- a/api/odk/controllers/get-manifest.js
+++ b/api/odk/controllers/get-manifest.js
@@ -3,6 +3,7 @@
 const createManifest = require('openrosa-manifest');
 
 const { getFormMetadata } = require('../../../util/xform');
+const Url = require('../../../util/url');
 
 module.exports = (req, res, next) => {
   const formId = req.params.formName;
@@ -17,7 +18,7 @@ module.exports = (req, res, next) => {
 
     const files = meta.assets.map(x => ({
       filename: x,
-      url: `${req.protocol}://${req.headers.host}/omk/data/forms/${formId}/${x}`
+      url: `${Url.baseUrl(req)}/omk/data/forms/${formId}/${x}`
     }));
 
     return createManifest(files, (err, xml) => {

--- a/api/odk/controllers/upload-form.js
+++ b/api/odk/controllers/upload-form.js
@@ -13,6 +13,7 @@ const tempy = require('tempy');
 
 const settings = require('../../../settings');
 const { getForms, loadXForm } = require('../../../util/xform');
+const Url = require('../../../util/url');
 
 const formsDir = settings.dataDir + '/forms/';
 
@@ -227,8 +228,8 @@ module.exports = function (req, res, next) {
               return res.status(201).json({
                 status: 201,
                 msg: `Converted ${xlsFilename} to an XForm and saved everything to the forms directory.`,
-                xFormUrl: `${req.protocol}://${req.headers.host}/omk/data/forms/${xformFilename}`,
-                xlsFormUrl: `${req.protocol}://${req.headers.host}/omk/data/forms/${xlsFilename}`
+                xFormUrl: `${Url.baseUrl(req)}/omk/data/forms/${xformFilename}`,
+                xlsFormUrl: `${Url.baseUrl(req)}/omk/data/forms/${xlsFilename}`
               });
             });
           });

--- a/api/odk/middlewares/openrosa-request-middleware.js
+++ b/api/odk/middlewares/openrosa-request-middleware.js
@@ -11,9 +11,13 @@ module.exports = function() {
 };
 
 function httpOrHttps(req) {
+    if (req.headers['x-forwarded-proto']) {
+        return req.headers['x-forwarded-proto'] + '://';
+    }
     return req.connection.encrypted ? 'https://' : 'http://';
 }
 
 function locationUrl(req) {
-    return httpOrHttps(req) + req.headers.host + req.originalUrl;
+    var host = req.headers['x-forwarded-host'] ? req.headers['x-forwarded-host'] : req.headers.host;
+    return httpOrHttps(req) + host + req.originalUrl;
 }

--- a/util/url.js
+++ b/util/url.js
@@ -21,6 +21,18 @@ Url.dataDirFileUrl = function (req, path, fileName) {
 };
 
 /**
+ * Returns a fully qualified base URL (protocol + host) for an API endpoint.
+ *
+ * @param req - http request that is pending
+ * @returns {string} - the base URL to the endpoint
+ */
+Url.baseUrl = function (req) {
+    var proto = req.headers['x-forwarded-proto'] ? req.headers['x-forwarded-proto'] : req.protocol;
+    var host = req.headers['x-forwarded-host'] ? req.headers['x-forwarded-host'] : req.headers.host;
+    return proto + '://' + host;
+}
+
+/**
  * Returns a fully qualified URL for an API endpoint.
  *
  * @param req - http request that is pending
@@ -29,7 +41,7 @@ Url.dataDirFileUrl = function (req, path, fileName) {
  */
 Url.apiUrl = function (req, path) {
     path = encodeURIComponent(path).replace(/%2F/g, '/'); // keep slashes
-    var base = req.protocol + '://' + req.headers.host;
+    var base = Url.baseUrl(req);
     return path[0] === '/' ? base + path : base + '/' + path;
 };
 


### PR DESCRIPTION
**Disclaimer:** I'm a sysadmin tasked with integrating OMK to a specific (but fairly commonly looking) environment featuring a reverse proxy server. I don't know specifics of OMK or NodeJS, so it's entirely possible that what I'm trying to achieve in this PR can be achieved much easier, however I haven't been able to find any documentation on this topic.

This PR aims to make OMK configurable and usable in environments with reverse proxy. In my case the scenario looks like
```
Client ---> HTTP proxy (HTTPS offload, public IP) ---> OMK in Docker container (HTTP, local IP)
```
In such case, the OMK doesn't know the proper protocol and HTTP host which it needs in order to build the URLs (e.g. in `formList`). Although the host header can be injected by the proxy itself, the protocol can't. In such scenarios, it's common to use `X-Forwarded-Proto` and `X-Forwarded-Host` headers to pass the original data into the application, so that's exactly what this PR does. If the headers are not set, the actual `req.protocol` and `req.headers.host` are used as they were up until now.